### PR TITLE
feat: replaces react-query with rtk

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -1,16 +1,10 @@
 import {NavigationContainer} from '@react-navigation/native';
-import {Box, NativeBaseProvider, Text, View} from 'native-base';
-import React, {useEffect, useState} from 'react';
-import {Alert, SafeAreaView} from 'react-native';
-import {SQLiteDatabase} from 'react-native-sqlite-storage';
-import {QueryClient, QueryClientProvider} from 'react-query';
+import {NativeBaseProvider, View} from 'native-base';
+import React from 'react';
+import {Provider} from 'react-redux';
 import {Inventory} from './components/Inventory';
-import {LoadingScreen} from './components/LoadingScreen';
-import {InventoryOptions} from './components/options/InventoryOptions';
-import {DBState} from './models/ItemIndex';
-import {getDBConnection, getDBState} from './services/db-service';
-
-const queryClient = new QueryClient();
+import {store} from './store';
+// import {InventoryOptions} from './components/InventoryOptions';
 
 const App = () => {
   // // Initialize database
@@ -43,13 +37,13 @@ const App = () => {
 
   return (
     <NavigationContainer>
-      <QueryClientProvider client={queryClient}>
+      <Provider store={store}>
         <NativeBaseProvider>
           <View p={1} flex="1">
             <Inventory />
           </View>
         </NativeBaseProvider>
-      </QueryClientProvider>
+      </Provider>
     </NavigationContainer>
   );
 };

--- a/components/Inventory.tsx
+++ b/components/Inventory.tsx
@@ -1,11 +1,29 @@
 import {createDrawerNavigator} from '@react-navigation/drawer';
-import React from 'react';
+import React, {useEffect} from 'react';
+import {useAppDispatch, useAppSelector} from '../hooks/redux';
+
 import {ArmorInventory} from '../screens/ArmorInventory';
 import {WeaponInventory} from '../screens/WeaponInventory';
+import {
+  fetchWeaponCategoriesAsync,
+  selectWeaponCategories,
+} from '../store/slices/weaponCategorySlice';
 
 const Drawer = createDrawerNavigator();
 
 export const Inventory = () => {
+  const dispatch = useAppDispatch();
+  const weaponCategoriesStatus = useAppSelector(
+    state => state.weaponCategories.status,
+  );
+  const weaponCategories = useAppSelector(selectWeaponCategories);
+
+  useEffect(() => {
+    if (weaponCategoriesStatus === 'idle' && weaponCategories === null) {
+      dispatch(fetchWeaponCategoriesAsync());
+    }
+  }, [weaponCategoriesStatus, dispatch, weaponCategories]);
+
   return (
     <Drawer.Navigator
       detachInactiveScreens

--- a/hooks/redux.ts
+++ b/hooks/redux.ts
@@ -1,0 +1,6 @@
+import {TypedUseSelectorHook, useDispatch, useSelector} from 'react-redux';
+import type {RootState, AppDispatch} from '../store';
+
+// Use throughout your app instead of plain `useDispatch` and `useSelector`
+export const useAppDispatch = () => useDispatch<AppDispatch>();
+export const useAppSelector: TypedUseSelectorHook<RootState> = useSelector;

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,7 @@
         "@react-navigation/drawer": "^6.4.1",
         "@react-navigation/native": "^6.0.10",
         "@react-navigation/stack": "^6.2.1",
+        "@reduxjs/toolkit": "^1.8.1",
         "lodash": "^4.17.21",
         "native-base": "^3.4.3",
         "react": "17.0.2",
@@ -27,7 +28,7 @@
         "react-native-svg": "^12.3.0",
         "react-native-windows": "0.68.2",
         "react-navigation": "^4.4.4",
-        "react-query": "^3.38.0"
+        "react-redux": "^8.0.1"
       },
       "devDependencies": {
         "@babel/core": "^7.12.9",
@@ -5648,6 +5649,29 @@
         "react": "^16.8.0 || ^17.0.0-rc.1"
       }
     },
+    "node_modules/@reduxjs/toolkit": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/@reduxjs/toolkit/-/toolkit-1.8.1.tgz",
+      "integrity": "sha512-Q6mzbTpO9nOYRnkwpDlFOAbQnd3g7zj7CtHAZWz5SzE5lcV97Tf8f3SzOO8BoPOMYBFgfZaqTUZqgGu+a0+Fng==",
+      "dependencies": {
+        "immer": "^9.0.7",
+        "redux": "^4.1.2",
+        "redux-thunk": "^2.4.1",
+        "reselect": "^4.1.5"
+      },
+      "peerDependencies": {
+        "react": "^16.9.0 || ^17.0.0 || ^18",
+        "react-redux": "^7.2.1 || ^8.0.0-beta"
+      },
+      "peerDependenciesMeta": {
+        "react": {
+          "optional": true
+        },
+        "react-redux": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@sideway/address": {
       "version": "4.1.4",
       "resolved": "https://registry.npmjs.org/@sideway/address/-/address-4.1.4.tgz",
@@ -5768,6 +5792,15 @@
       "version": "2.0.41",
       "resolved": "https://registry.npmjs.org/@types/hammerjs/-/hammerjs-2.0.41.tgz",
       "integrity": "sha512-ewXv/ceBaJprikMcxCmWU1FKyMAQ2X7a9Gtmzw8fcg2kIePI1crERDM818W+XYrxqdBBOdlf2rm137bU+BltCA=="
+    },
+    "node_modules/@types/hoist-non-react-statics": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/@types/hoist-non-react-statics/-/hoist-non-react-statics-3.3.1.tgz",
+      "integrity": "sha512-iMIqiko6ooLrTh1joXodJK5X9xeEALT1kM5G3ZLhD3hszxBdIEd5C75U834D9mLcINgD4OyZf5uQXjkuYydWvA==",
+      "dependencies": {
+        "@types/react": "*",
+        "hoist-non-react-statics": "^3.3.0"
+      }
     },
     "node_modules/@types/invariant": {
       "version": "2.2.35",
@@ -5917,6 +5950,11 @@
       "dependencies": {
         "@types/node": "*"
       }
+    },
+    "node_modules/@types/use-sync-external-store": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/@types/use-sync-external-store/-/use-sync-external-store-0.0.3.tgz",
+      "integrity": "sha512-EwmlvuaxPNej9+T4v5AuBPJa2x2UOJVdjCtDHgcDqitUeOtjnJKJ+apYjVcAoBEMjKW1VVFGZLUb5+qqa09XFA=="
     },
     "node_modules/@types/yargs": {
       "version": "15.0.14",
@@ -7109,21 +7147,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/broadcast-channel": {
-      "version": "3.7.0",
-      "resolved": "https://registry.npmjs.org/broadcast-channel/-/broadcast-channel-3.7.0.tgz",
-      "integrity": "sha512-cIAKJXAxGJceNZGTZSBzMxzyOn72cVgPnKx4dc6LRjQgbaJUQqhy5rzL3zbMxkMWsGKkv2hSFkPRMEXfoMZ2Mg==",
-      "dependencies": {
-        "@babel/runtime": "^7.7.2",
-        "detect-node": "^2.1.0",
-        "js-sha3": "0.8.0",
-        "microseconds": "0.2.0",
-        "nano-time": "1.0.0",
-        "oblivious-set": "1.0.0",
-        "rimraf": "3.0.2",
-        "unload": "2.2.0"
-      }
-    },
     "node_modules/browser-process-hrtime": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/browser-process-hrtime/-/browser-process-hrtime-1.0.0.tgz",
@@ -8016,11 +8039,6 @@
       "engines": {
         "node": ">=8"
       }
-    },
-    "node_modules/detect-node": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/detect-node/-/detect-node-2.1.0.tgz",
-      "integrity": "sha512-T0NIuQpnTvFDATNuHN5roPwSBG83rFsuO+MXXH9/3N1eFbn4wcPjttvjMLEPWJ0RGUYgQE7cGgS3tNxbqCGM7g=="
     },
     "node_modules/diagnostic-channel": {
       "version": "1.1.0",
@@ -10118,6 +10136,15 @@
       },
       "engines": {
         "node": ">=4.0"
+      }
+    },
+    "node_modules/immer": {
+      "version": "9.0.12",
+      "resolved": "https://registry.npmjs.org/immer/-/immer-9.0.12.tgz",
+      "integrity": "sha512-lk7UNmSbAukB5B6dh9fnh5D0bJTOFKxVg2cyJWTYrWRfhLrLMBquONcUs3aFq507hNoIZEDDh8lb8UtOizSMhA==",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/immer"
       }
     },
     "node_modules/import-fresh": {
@@ -12306,11 +12333,6 @@
         "@sideway/pinpoint": "^2.0.0"
       }
     },
-    "node_modules/js-sha3": {
-      "version": "0.8.0",
-      "resolved": "https://registry.npmjs.org/js-sha3/-/js-sha3-0.8.0.tgz",
-      "integrity": "sha512-gF1cRrHhIzNfToc802P800N8PpXS+evLLXfsVpowqmAFR9uwbi89WvXg2QspOmXL8QL86J4T1EpFu+yUkwJY3Q=="
-    },
     "node_modules/js-tokens": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
@@ -12982,15 +13004,6 @@
       },
       "engines": {
         "node": ">=0.10.0"
-      }
-    },
-    "node_modules/match-sorter": {
-      "version": "6.3.1",
-      "resolved": "https://registry.npmjs.org/match-sorter/-/match-sorter-6.3.1.tgz",
-      "integrity": "sha512-mxybbo3pPNuA+ZuCUhm5bwNkXrJTbsk5VWbR5wiwz/GC6LIiegBGn2w3O08UG/jdbYLinw51fSQ5xNU1U3MgBw==",
-      "dependencies": {
-        "@babel/runtime": "^7.12.5",
-        "remove-accents": "0.4.2"
       }
     },
     "node_modules/mdn-data": {
@@ -13728,11 +13741,6 @@
         "node": ">=8.6"
       }
     },
-    "node_modules/microseconds": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/microseconds/-/microseconds-0.2.0.tgz",
-      "integrity": "sha512-n7DHHMjR1avBbSpsTBj6fmMGh2AGrifVV4e+WYc3Q9lO+xnSZ3NyhcBND3vzzatt05LFhoKFRxrIyklmLlUtyA=="
-    },
     "node_modules/mime": {
       "version": "2.6.0",
       "resolved": "https://registry.npmjs.org/mime/-/mime-2.6.0.tgz",
@@ -13821,14 +13829,6 @@
       "integrity": "sha512-71ippSywq5Yb7/tVYyGbkBggbU8H3u5Rz56fH60jGFgr8uHwxs+aSKeqmluIVzM0m0kB7xQjKS6qPfd0b2ZoqQ==",
       "bin": {
         "mustache": "bin/mustache"
-      }
-    },
-    "node_modules/nano-time": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/nano-time/-/nano-time-1.0.0.tgz",
-      "integrity": "sha1-sFVPaa2J4i0JB/ehKwmTpdlhN+8=",
-      "dependencies": {
-        "big-integer": "^1.6.16"
       }
     },
     "node_modules/nanoid": {
@@ -14323,11 +14323,6 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
-    },
-    "node_modules/oblivious-set": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/oblivious-set/-/oblivious-set-1.0.0.tgz",
-      "integrity": "sha512-z+pI07qxo4c2CulUHCDf9lcqDlMSo72N/4rLUpRXf6fu+q8vjt8y0xS+Tlf8NTJDdTXHbdeO1n3MlbctwEoXZw=="
     },
     "node_modules/on-finished": {
       "version": "2.3.0",
@@ -15301,30 +15296,48 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/react-query": {
-      "version": "3.38.0",
-      "resolved": "https://registry.npmjs.org/react-query/-/react-query-3.38.0.tgz",
-      "integrity": "sha512-VRbCTRrDfC5FsB70+JfZuxFRv9SAvkZ1h36MsN8+QaDN+NWB6s1vJndqpoLQnJqN0COTG2zsInMq0KFdYze6TA==",
+    "node_modules/react-redux": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/react-redux/-/react-redux-8.0.1.tgz",
+      "integrity": "sha512-LMZMsPY4DYdZfLJgd7i79n5Kps5N9XVLCJJeWAaPYTV+Eah2zTuBjTxKtNEbjiyitbq80/eIkm55CYSLqAub3w==",
       "dependencies": {
-        "@babel/runtime": "^7.5.5",
-        "broadcast-channel": "^3.4.1",
-        "match-sorter": "^6.0.2"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/tannerlinsley"
+        "@babel/runtime": "^7.12.1",
+        "@types/hoist-non-react-statics": "^3.3.1",
+        "@types/use-sync-external-store": "^0.0.3",
+        "hoist-non-react-statics": "^3.3.2",
+        "react-is": "^18.0.0",
+        "use-sync-external-store": "^1.0.0"
       },
       "peerDependencies": {
-        "react": "^16.8.0 || ^17.0.0 || ^18.0.0"
+        "@types/react": "^16.8 || ^17.0 || ^18.0",
+        "@types/react-dom": "^16.8 || ^17.0 || ^18.0",
+        "react": "^16.8 || ^17.0 || ^18.0",
+        "react-dom": "^16.8 || ^17.0 || ^18.0",
+        "react-native": ">=0.59",
+        "redux": "^4"
       },
       "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        },
         "react-dom": {
           "optional": true
         },
         "react-native": {
           "optional": true
+        },
+        "redux": {
+          "optional": true
         }
       }
+    },
+    "node_modules/react-redux/node_modules/react-is": {
+      "version": "18.1.0",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.1.0.tgz",
+      "integrity": "sha512-Fl7FuabXsJnV5Q1qIOQwx/sagGF18kogb4gpfcG4gjLBWO0WDiiz1ko/ExayuxE7InyQkBLkxRFG5oxY6Uu3Kg=="
     },
     "node_modules/react-refresh": {
       "version": "0.4.3",
@@ -15487,6 +15500,22 @@
         "node": ">= 0.10"
       }
     },
+    "node_modules/redux": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/redux/-/redux-4.2.0.tgz",
+      "integrity": "sha512-oSBmcKKIuIR4ME29/AeNUnl5L+hvBq7OaJWzaptTQJAntaPvxIJqfnjbaEiCzzaIz+XmVILfqAM3Ob0aXLPfjA==",
+      "dependencies": {
+        "@babel/runtime": "^7.9.2"
+      }
+    },
+    "node_modules/redux-thunk": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/redux-thunk/-/redux-thunk-2.4.1.tgz",
+      "integrity": "sha512-OOYGNY5Jy2TWvTL1KgAlVy6dcx3siPJ1wTq741EPyUKfn6W6nChdICjZwCd0p8AZBs5kWpZlbkXW2nE/zjUa+Q==",
+      "peerDependencies": {
+        "redux": "^4"
+      }
+    },
     "node_modules/regenerate": {
       "version": "1.4.2",
       "resolved": "https://registry.npmjs.org/regenerate/-/regenerate-1.4.2.tgz",
@@ -15597,11 +15626,6 @@
         "jsesc": "bin/jsesc"
       }
     },
-    "node_modules/remove-accents": {
-      "version": "0.4.2",
-      "resolved": "https://registry.npmjs.org/remove-accents/-/remove-accents-0.4.2.tgz",
-      "integrity": "sha1-CkPTqq4egNuRngeuJUsoXZ4ce7U="
-    },
     "node_modules/remove-trailing-separator": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/remove-trailing-separator/-/remove-trailing-separator-1.1.0.tgz",
@@ -15645,6 +15669,11 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-2.0.0.tgz",
       "integrity": "sha512-NKN5kMDylKuldxYLSUfrbo5Tuzh4hd+2E8NPPX02mZtn1VuREQToYe/ZdlJy+J3uCpfaiGF05e7B8W0iXbQHmg=="
+    },
+    "node_modules/reselect": {
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/reselect/-/reselect-4.1.5.tgz",
+      "integrity": "sha512-uVdlz8J7OO+ASpBYoz1Zypgx0KasCY20H+N8JD13oUMtPvSHQuscrHop4KbXrbsBcdB9Ds7lVK7eRkBIfO43vQ=="
     },
     "node_modules/resolve": {
       "version": "1.22.0",
@@ -15742,6 +15771,7 @@
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
       "integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
+      "dev": true,
       "dependencies": {
         "glob": "^7.1.3"
       },
@@ -17531,15 +17561,6 @@
         "node": ">= 4.0.0"
       }
     },
-    "node_modules/unload": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/unload/-/unload-2.2.0.tgz",
-      "integrity": "sha512-B60uB5TNBLtN6/LsgAf3udH9saB5p7gqJwcFfbOEZ8BcBHnGwCf6G/TGiEqkRAxX7zAFIUtzdrXQSdL3Q/wqNA==",
-      "dependencies": {
-        "@babel/runtime": "^7.6.2",
-        "detect-node": "^2.0.4"
-      }
-    },
     "node_modules/unpipe": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
@@ -17624,6 +17645,14 @@
       },
       "peerDependencies": {
         "react": "^16.8.0 || ^17.0.0"
+      }
+    },
+    "node_modules/use-sync-external-store": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.1.0.tgz",
+      "integrity": "sha512-SEnieB2FPKEVne66NpXPd1Np4R1lTNKfjuy3XdIoPQKYBAFdzbzSZlSn1KJZUiihQLQC5Znot4SBz1EOTBwQAQ==",
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0"
       }
     },
     "node_modules/username": {
@@ -22328,6 +22357,17 @@
         "@react-types/shared": "^3.11.2"
       }
     },
+    "@reduxjs/toolkit": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/@reduxjs/toolkit/-/toolkit-1.8.1.tgz",
+      "integrity": "sha512-Q6mzbTpO9nOYRnkwpDlFOAbQnd3g7zj7CtHAZWz5SzE5lcV97Tf8f3SzOO8BoPOMYBFgfZaqTUZqgGu+a0+Fng==",
+      "requires": {
+        "immer": "^9.0.7",
+        "redux": "^4.1.2",
+        "redux-thunk": "^2.4.1",
+        "reselect": "^4.1.5"
+      }
+    },
     "@sideway/address": {
       "version": "4.1.4",
       "resolved": "https://registry.npmjs.org/@sideway/address/-/address-4.1.4.tgz",
@@ -22444,6 +22484,15 @@
       "version": "2.0.41",
       "resolved": "https://registry.npmjs.org/@types/hammerjs/-/hammerjs-2.0.41.tgz",
       "integrity": "sha512-ewXv/ceBaJprikMcxCmWU1FKyMAQ2X7a9Gtmzw8fcg2kIePI1crERDM818W+XYrxqdBBOdlf2rm137bU+BltCA=="
+    },
+    "@types/hoist-non-react-statics": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/@types/hoist-non-react-statics/-/hoist-non-react-statics-3.3.1.tgz",
+      "integrity": "sha512-iMIqiko6ooLrTh1joXodJK5X9xeEALT1kM5G3ZLhD3hszxBdIEd5C75U834D9mLcINgD4OyZf5uQXjkuYydWvA==",
+      "requires": {
+        "@types/react": "*",
+        "hoist-non-react-statics": "^3.3.0"
+      }
     },
     "@types/invariant": {
       "version": "2.2.35",
@@ -22595,6 +22644,11 @@
       "requires": {
         "@types/node": "*"
       }
+    },
+    "@types/use-sync-external-store": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/@types/use-sync-external-store/-/use-sync-external-store-0.0.3.tgz",
+      "integrity": "sha512-EwmlvuaxPNej9+T4v5AuBPJa2x2UOJVdjCtDHgcDqitUeOtjnJKJ+apYjVcAoBEMjKW1VVFGZLUb5+qqa09XFA=="
     },
     "@types/yargs": {
       "version": "15.0.14",
@@ -23439,21 +23493,6 @@
         "fill-range": "^7.0.1"
       }
     },
-    "broadcast-channel": {
-      "version": "3.7.0",
-      "resolved": "https://registry.npmjs.org/broadcast-channel/-/broadcast-channel-3.7.0.tgz",
-      "integrity": "sha512-cIAKJXAxGJceNZGTZSBzMxzyOn72cVgPnKx4dc6LRjQgbaJUQqhy5rzL3zbMxkMWsGKkv2hSFkPRMEXfoMZ2Mg==",
-      "requires": {
-        "@babel/runtime": "^7.7.2",
-        "detect-node": "^2.1.0",
-        "js-sha3": "0.8.0",
-        "microseconds": "0.2.0",
-        "nano-time": "1.0.0",
-        "oblivious-set": "1.0.0",
-        "rimraf": "3.0.2",
-        "unload": "2.2.0"
-      }
-    },
     "browser-process-hrtime": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/browser-process-hrtime/-/browser-process-hrtime-1.0.0.tgz",
@@ -24145,11 +24184,6 @@
       "resolved": "https://registry.npmjs.org/detect-newline/-/detect-newline-3.1.0.tgz",
       "integrity": "sha512-TLz+x/vEXm/Y7P7wn1EJFNLxYpUD4TgMosxY6fAVJUnJMbupHBOncxyWUG9OpTaH9EBD7uFI5LfEgmMOc54DsA==",
       "dev": true
-    },
-    "detect-node": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/detect-node/-/detect-node-2.1.0.tgz",
-      "integrity": "sha512-T0NIuQpnTvFDATNuHN5roPwSBG83rFsuO+MXXH9/3N1eFbn4wcPjttvjMLEPWJ0RGUYgQE7cGgS3tNxbqCGM7g=="
     },
     "diagnostic-channel": {
       "version": "1.1.0",
@@ -25723,6 +25757,11 @@
       "version": "0.6.3",
       "resolved": "https://registry.npmjs.org/image-size/-/image-size-0.6.3.tgz",
       "integrity": "sha512-47xSUiQioGaB96nqtp5/q55m0aBQSQdyIloMOc/x+QVTDZLNmXE892IIDrJ0hM1A5vcNUDD5tDffkSP5lCaIIA=="
+    },
+    "immer": {
+      "version": "9.0.12",
+      "resolved": "https://registry.npmjs.org/immer/-/immer-9.0.12.tgz",
+      "integrity": "sha512-lk7UNmSbAukB5B6dh9fnh5D0bJTOFKxVg2cyJWTYrWRfhLrLMBquONcUs3aFq507hNoIZEDDh8lb8UtOizSMhA=="
     },
     "import-fresh": {
       "version": "3.3.0",
@@ -27333,11 +27372,6 @@
         "@sideway/pinpoint": "^2.0.0"
       }
     },
-    "js-sha3": {
-      "version": "0.8.0",
-      "resolved": "https://registry.npmjs.org/js-sha3/-/js-sha3-0.8.0.tgz",
-      "integrity": "sha512-gF1cRrHhIzNfToc802P800N8PpXS+evLLXfsVpowqmAFR9uwbi89WvXg2QspOmXL8QL86J4T1EpFu+yUkwJY3Q=="
-    },
     "js-tokens": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
@@ -27872,15 +27906,6 @@
       "integrity": "sha1-7Nyo8TFE5mDxtb1B8S80edmN+48=",
       "requires": {
         "object-visit": "^1.0.0"
-      }
-    },
-    "match-sorter": {
-      "version": "6.3.1",
-      "resolved": "https://registry.npmjs.org/match-sorter/-/match-sorter-6.3.1.tgz",
-      "integrity": "sha512-mxybbo3pPNuA+ZuCUhm5bwNkXrJTbsk5VWbR5wiwz/GC6LIiegBGn2w3O08UG/jdbYLinw51fSQ5xNU1U3MgBw==",
-      "requires": {
-        "@babel/runtime": "^7.12.5",
-        "remove-accents": "0.4.2"
       }
     },
     "mdn-data": {
@@ -28505,11 +28530,6 @@
         "picomatch": "^2.3.1"
       }
     },
-    "microseconds": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/microseconds/-/microseconds-0.2.0.tgz",
-      "integrity": "sha512-n7DHHMjR1avBbSpsTBj6fmMGh2AGrifVV4e+WYc3Q9lO+xnSZ3NyhcBND3vzzatt05LFhoKFRxrIyklmLlUtyA=="
-    },
     "mime": {
       "version": "2.6.0",
       "resolved": "https://registry.npmjs.org/mime/-/mime-2.6.0.tgz",
@@ -28572,14 +28592,6 @@
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/mustache/-/mustache-4.2.0.tgz",
       "integrity": "sha512-71ippSywq5Yb7/tVYyGbkBggbU8H3u5Rz56fH60jGFgr8uHwxs+aSKeqmluIVzM0m0kB7xQjKS6qPfd0b2ZoqQ=="
-    },
-    "nano-time": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/nano-time/-/nano-time-1.0.0.tgz",
-      "integrity": "sha1-sFVPaa2J4i0JB/ehKwmTpdlhN+8=",
-      "requires": {
-        "big-integer": "^1.6.16"
-      }
     },
     "nanoid": {
       "version": "3.3.3",
@@ -28960,11 +28972,6 @@
         "define-properties": "^1.1.3",
         "es-abstract": "^1.19.1"
       }
-    },
-    "oblivious-set": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/oblivious-set/-/oblivious-set-1.0.0.tgz",
-      "integrity": "sha512-z+pI07qxo4c2CulUHCDf9lcqDlMSo72N/4rLUpRXf6fu+q8vjt8y0xS+Tlf8NTJDdTXHbdeO1n3MlbctwEoXZw=="
     },
     "on-finished": {
       "version": "2.3.0",
@@ -29693,14 +29700,24 @@
         }
       }
     },
-    "react-query": {
-      "version": "3.38.0",
-      "resolved": "https://registry.npmjs.org/react-query/-/react-query-3.38.0.tgz",
-      "integrity": "sha512-VRbCTRrDfC5FsB70+JfZuxFRv9SAvkZ1h36MsN8+QaDN+NWB6s1vJndqpoLQnJqN0COTG2zsInMq0KFdYze6TA==",
+    "react-redux": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/react-redux/-/react-redux-8.0.1.tgz",
+      "integrity": "sha512-LMZMsPY4DYdZfLJgd7i79n5Kps5N9XVLCJJeWAaPYTV+Eah2zTuBjTxKtNEbjiyitbq80/eIkm55CYSLqAub3w==",
       "requires": {
-        "@babel/runtime": "^7.5.5",
-        "broadcast-channel": "^3.4.1",
-        "match-sorter": "^6.0.2"
+        "@babel/runtime": "^7.12.1",
+        "@types/hoist-non-react-statics": "^3.3.1",
+        "@types/use-sync-external-store": "^0.0.3",
+        "hoist-non-react-statics": "^3.3.2",
+        "react-is": "^18.0.0",
+        "use-sync-external-store": "^1.0.0"
+      },
+      "dependencies": {
+        "react-is": {
+          "version": "18.1.0",
+          "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.1.0.tgz",
+          "integrity": "sha512-Fl7FuabXsJnV5Q1qIOQwx/sagGF18kogb4gpfcG4gjLBWO0WDiiz1ko/ExayuxE7InyQkBLkxRFG5oxY6Uu3Kg=="
+        }
       }
     },
     "react-refresh": {
@@ -29833,6 +29850,20 @@
         "resolve": "^1.1.6"
       }
     },
+    "redux": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/redux/-/redux-4.2.0.tgz",
+      "integrity": "sha512-oSBmcKKIuIR4ME29/AeNUnl5L+hvBq7OaJWzaptTQJAntaPvxIJqfnjbaEiCzzaIz+XmVILfqAM3Ob0aXLPfjA==",
+      "requires": {
+        "@babel/runtime": "^7.9.2"
+      }
+    },
+    "redux-thunk": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/redux-thunk/-/redux-thunk-2.4.1.tgz",
+      "integrity": "sha512-OOYGNY5Jy2TWvTL1KgAlVy6dcx3siPJ1wTq741EPyUKfn6W6nChdICjZwCd0p8AZBs5kWpZlbkXW2nE/zjUa+Q==",
+      "requires": {}
+    },
     "regenerate": {
       "version": "1.4.2",
       "resolved": "https://registry.npmjs.org/regenerate/-/regenerate-1.4.2.tgz",
@@ -29918,11 +29949,6 @@
         }
       }
     },
-    "remove-accents": {
-      "version": "0.4.2",
-      "resolved": "https://registry.npmjs.org/remove-accents/-/remove-accents-0.4.2.tgz",
-      "integrity": "sha1-CkPTqq4egNuRngeuJUsoXZ4ce7U="
-    },
     "remove-trailing-separator": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/remove-trailing-separator/-/remove-trailing-separator-1.1.0.tgz",
@@ -29954,6 +29980,11 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-2.0.0.tgz",
       "integrity": "sha512-NKN5kMDylKuldxYLSUfrbo5Tuzh4hd+2E8NPPX02mZtn1VuREQToYe/ZdlJy+J3uCpfaiGF05e7B8W0iXbQHmg=="
+    },
+    "reselect": {
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/reselect/-/reselect-4.1.5.tgz",
+      "integrity": "sha512-uVdlz8J7OO+ASpBYoz1Zypgx0KasCY20H+N8JD13oUMtPvSHQuscrHop4KbXrbsBcdB9Ds7lVK7eRkBIfO43vQ=="
     },
     "resolve": {
       "version": "1.22.0",
@@ -30024,6 +30055,7 @@
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
       "integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
+      "dev": true,
       "requires": {
         "glob": "^7.1.3"
       }
@@ -31430,15 +31462,6 @@
       "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.2.tgz",
       "integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg=="
     },
-    "unload": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/unload/-/unload-2.2.0.tgz",
-      "integrity": "sha512-B60uB5TNBLtN6/LsgAf3udH9saB5p7gqJwcFfbOEZ8BcBHnGwCf6G/TGiEqkRAxX7zAFIUtzdrXQSdL3Q/wqNA==",
-      "requires": {
-        "@babel/runtime": "^7.6.2",
-        "detect-node": "^2.0.4"
-      }
-    },
     "unpipe": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
@@ -31506,6 +31529,12 @@
       "requires": {
         "object-assign": "^4.1.1"
       }
+    },
+    "use-sync-external-store": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.1.0.tgz",
+      "integrity": "sha512-SEnieB2FPKEVne66NpXPd1Np4R1lTNKfjuy3XdIoPQKYBAFdzbzSZlSn1KJZUiihQLQC5Znot4SBz1EOTBwQAQ==",
+      "requires": {}
     },
     "username": {
       "version": "5.1.0",

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "@react-navigation/drawer": "^6.4.1",
     "@react-navigation/native": "^6.0.10",
     "@react-navigation/stack": "^6.2.1",
+    "@reduxjs/toolkit": "^1.8.1",
     "lodash": "^4.17.21",
     "native-base": "^3.4.3",
     "react": "17.0.2",
@@ -30,7 +31,7 @@
     "react-native-svg": "^12.3.0",
     "react-native-windows": "0.68.2",
     "react-navigation": "^4.4.4",
-    "react-query": "^3.38.0"
+    "react-redux": "^8.0.1"
   },
   "devDependencies": {
     "@babel/core": "^7.12.9",

--- a/screens/ArmorInventory.tsx
+++ b/screens/ArmorInventory.tsx
@@ -1,16 +1,11 @@
-import {FlatList, Text, View} from 'native-base';
+import {FlatList, View} from 'native-base';
 import React from 'react';
-import {useQuery} from 'react-query';
 import {ArmorItemComponent} from '../components/ArmorItem';
 import {LoadingScreen} from '../components/LoadingScreen';
-import {getArmorItems, getDBConnection} from '../services/db-service';
+import {useGetAllArmorQuery} from '../store/slices/databaseSlice';
 
 export const ArmorInventory = () => {
-  const {data, isLoading} = useQuery(['Inventory', 'Armor'], async () => {
-    const db = await getDBConnection();
-
-    return getArmorItems(db, 'items');
-  });
+  const {data, isLoading} = useGetAllArmorQuery();
 
   if (isLoading || !data) {
     return <LoadingScreen text={'Loading armor...'} />;

--- a/screens/WeaponInventory.tsx
+++ b/screens/WeaponInventory.tsx
@@ -1,24 +1,11 @@
-import {Box, Heading, SectionList, Text} from 'native-base';
+import {Box, Heading, SectionList} from 'native-base';
 import React from 'react';
-import {useQuery} from 'react-query';
 import {LoadingScreen} from '../components/LoadingScreen';
 import {WeaponItemComponent} from '../components/WeaponItem';
-import {
-  getDBConnection,
-  getDBWeaponsState,
-  getWeaponItems,
-} from '../services/db-service';
+import {useGetAllWeaponsQuery} from '../store/slices/databaseSlice';
 
 export const WeaponInventory = () => {
-  const {data, isLoading} = useQuery(['Inventory', 'Weapons'], async () => {
-    const db = await getDBConnection();
-    const state = await getDBWeaponsState(db);
-    const list = await getWeaponItems(db, state, 'items');
-    return {
-      list: list,
-      state: state,
-    };
-  });
+  const {data, isLoading} = useGetAllWeaponsQuery();
 
   if (isLoading || !data) {
     return <LoadingScreen text={'Loading weapons...'} />;

--- a/services/db-service.ts
+++ b/services/db-service.ts
@@ -26,6 +26,8 @@ const getItems = async (
   itemType: number,
   parentTable: String,
 ): Promise<Item[]> => {
+  console.log('🚀 ~ file: db-service.ts ~ line 29 ~ itemType', itemType);
+  console.log('🚀 ~ file: db-service.ts ~ line 29 ~ parentTable', parentTable);
   try {
     const items: Item[] = [];
     const results = await db.executeSql(
@@ -59,6 +61,7 @@ export const getArmorItems = async (
   db: SQLite.SQLiteDatabase,
   tableName: String,
 ): Promise<ArmorList> => {
+  console.log('🚀 ~ file: db-service.ts ~ line 64 ~ tableName', tableName);
   try {
     const itemProps = await getItems(db, ITEM_TYPE.Armor, tableName);
     const items: ArmorItem[] = [];
@@ -98,6 +101,7 @@ export const getWeaponItems = async (
   dbWeaponsState: DBWeaponsState,
   tableName: String,
 ): Promise<WeaponsList> => {
+  console.log('🚀 ~ file: db-service.ts ~ line 104 ~ tableName', tableName);
   try {
     // GET WEAPONS
     const itemProps = await getItems(db, ITEM_TYPE.Weapons, tableName);

--- a/services/db-service.ts
+++ b/services/db-service.ts
@@ -26,8 +26,6 @@ const getItems = async (
   itemType: number,
   parentTable: String,
 ): Promise<Item[]> => {
-  console.log('🚀 ~ file: db-service.ts ~ line 29 ~ itemType', itemType);
-  console.log('🚀 ~ file: db-service.ts ~ line 29 ~ parentTable', parentTable);
   try {
     const items: Item[] = [];
     const results = await db.executeSql(
@@ -61,7 +59,6 @@ export const getArmorItems = async (
   db: SQLite.SQLiteDatabase,
   tableName: String,
 ): Promise<ArmorList> => {
-  console.log('🚀 ~ file: db-service.ts ~ line 64 ~ tableName', tableName);
   try {
     const itemProps = await getItems(db, ITEM_TYPE.Armor, tableName);
     const items: ArmorItem[] = [];
@@ -101,7 +98,6 @@ export const getWeaponItems = async (
   dbWeaponsState: DBWeaponsState,
   tableName: String,
 ): Promise<WeaponsList> => {
-  console.log('🚀 ~ file: db-service.ts ~ line 104 ~ tableName', tableName);
   try {
     // GET WEAPONS
     const itemProps = await getItems(db, ITEM_TYPE.Weapons, tableName);

--- a/store/index.ts
+++ b/store/index.ts
@@ -1,0 +1,22 @@
+import {Action, configureStore, ThunkAction} from '@reduxjs/toolkit';
+import {databaseSlice} from './slices/databaseSlice';
+
+import weaponCategoriesReducer from './slices/weaponCategorySlice';
+
+export const store = configureStore({
+  reducer: {
+    weaponCategories: weaponCategoriesReducer,
+    [databaseSlice.reducerPath]: databaseSlice.reducer,
+  },
+  middleware: getDefaultMiddleware =>
+    getDefaultMiddleware().concat(databaseSlice.middleware),
+});
+
+export type RootState = ReturnType<typeof store.getState>;
+export type AppDispatch = typeof store.dispatch;
+export type AppThunk<ReturnType = void> = ThunkAction<
+  ReturnType,
+  RootState,
+  unknown,
+  Action<string>
+>;

--- a/store/slices/databaseSlice.ts
+++ b/store/slices/databaseSlice.ts
@@ -1,0 +1,43 @@
+import {createApi, fakeBaseQuery} from '@reduxjs/toolkit/query/react';
+import {ArmorList, DBWeaponsState, WeaponsList} from '../../models/ItemIndex';
+import {
+  getArmorItems,
+  getWeaponItems,
+  getDBConnection,
+  getDBWeaponsState,
+} from '../../services/db-service';
+
+export const databaseSlice = createApi({
+  baseQuery: fakeBaseQuery(),
+  reducerPath: 'database',
+  endpoints: build => ({
+    getAllArmor: build.query<ArmorList, void>({
+      queryFn: async () => {
+        try {
+          const db = await getDBConnection();
+          const data = await getArmorItems(db, 'Items');
+          return {data};
+        } catch (error) {
+          return {error: {data: "Can't get Armor", status: 500}};
+        }
+      },
+    }),
+    getAllWeapons: build.query<
+      {list: WeaponsList; state: DBWeaponsState},
+      void
+    >({
+      queryFn: async () => {
+        try {
+          const db = await getDBConnection();
+          const weaponState = await getDBWeaponsState(db);
+          const data = await getWeaponItems(db, weaponState, 'Items');
+          return {data: {state: weaponState, list: data}};
+        } catch (error) {
+          return {error: {data: "Can't get Armor", status: 500}};
+        }
+      },
+    }),
+  }),
+});
+
+export const {useGetAllArmorQuery, useGetAllWeaponsQuery} = databaseSlice;

--- a/store/slices/weaponCategorySlice.ts
+++ b/store/slices/weaponCategorySlice.ts
@@ -1,0 +1,53 @@
+import {createAsyncThunk, createSlice} from '@reduxjs/toolkit';
+import {RootState} from '..';
+import {WeaponCategoryList} from '../../models/ItemIndex';
+import {
+  getDBConnection,
+  getDBWeaponsState,
+  getWeaponItems,
+} from '../../services/db-service';
+
+export interface WeaponCategoryState {
+  categories: WeaponCategoryList | null;
+  status: 'idle' | 'loading' | 'failed';
+}
+
+const initialState: WeaponCategoryState = {
+  categories: null,
+  status: 'idle',
+};
+
+export const fetchWeaponCategoriesAsync = createAsyncThunk(
+  'weaponCategory/fetchCategories',
+  async () => {
+    const db = await getDBConnection();
+    const weaponState = await getDBWeaponsState(db);
+    const response = await getWeaponItems(db, weaponState, 'Items');
+
+    return response.items;
+  },
+);
+
+export const weaponCategorySlice = createSlice({
+  name: 'weaponCategories',
+  initialState,
+  reducers: {},
+  extraReducers: builder => {
+    builder
+      .addCase(fetchWeaponCategoriesAsync.pending, state => {
+        state.status = 'loading';
+      })
+      .addCase(fetchWeaponCategoriesAsync.fulfilled, (state, action) => {
+        state.status = 'idle';
+        state.categories = action.payload;
+      })
+      .addCase(fetchWeaponCategoriesAsync.rejected, state => {
+        state.status = 'failed';
+      });
+  },
+});
+
+export const selectWeaponCategories = (state: RootState) =>
+  state.weaponCategories.categories;
+
+export default weaponCategorySlice.reducer;


### PR DESCRIPTION
Replace `react-query` with `redux-toolkit` + `rtk-query`

Theres more to be done here but this is the base. The Armor/Weapon screens use a `databaseSlice` so that we get the `useGetAll*Query()` with loading states and all that.

In `components/Inventory.tsx` theres an example of loading the weapon categories into state so that it's available across the entire app